### PR TITLE
Fixed a issue when comparing null values with <, <=, >, >= operators

### DIFF
--- a/src/NReco.LambdaParser.Portable.sln
+++ b/src/NReco.LambdaParser.Portable.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NReco.LambdaParser", "NReco.LambdaParser\NReco.LambdaParser.Portable.csproj", "{2E4066D1-A58E-44BB-AB15-63DF19AADAEF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NReco.LambdaParser.Portable", "NReco.LambdaParser\NReco.LambdaParser.Portable.csproj", "{2E4066D1-A58E-44BB-AB15-63DF19AADAEF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NReco.LambdaParser.Tests", "NReco.LambdaParser.Tests\NReco.LambdaParser.Tests.csproj", "{7C5C1806-C3A7-494A-9EF0-A6304EBB5BEA}"
 EndProject

--- a/src/NReco.LambdaParser/Linq/LambdaParameterWrapper.cs
+++ b/src/NReco.LambdaParser/Linq/LambdaParameterWrapper.cs
@@ -245,23 +245,92 @@ namespace NReco.Linq {
 			return c1 != c2bool;
 		}
 
-		public static bool operator >(LambdaParameterWrapper c1, LambdaParameterWrapper c2) {
-			var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
-			return compareRes>0;
-		}
-		public static bool operator <(LambdaParameterWrapper c1, LambdaParameterWrapper c2) {
-			var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
-			return compareRes < 0;
-		}
+        public static bool operator >(LambdaParameterWrapper c1, LambdaParameterWrapper c2)
+        {
+            /*
+                Change 20.06.2017
 
-		public static bool operator >=(LambdaParameterWrapper c1, LambdaParameterWrapper c2) {
-			var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
-			return compareRes >= 0;
-		}
-		public static bool operator <=(LambdaParameterWrapper c1, LambdaParameterWrapper c2) {
-			var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
-			return compareRes <= 0;
-		}
+                This operator should return false if one or both operands are null
+
+                Example:
+
+                The previous version would return 'true' for expression: (new System.TimeSpan(15,0,0) >  null)
+                Now it returns false. That is now the exactly result which original c# code would return.
+            */
+
+            if (c1.Value == null || c2.Value == null)
+                return false;
+            else
+            {
+                var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
+                return compareRes > 0;
+            }
+        }
+        public static bool operator <(LambdaParameterWrapper c1, LambdaParameterWrapper c2)
+        {
+            /*
+               Change 20.06.2017
+
+               This operator should return false if one or both operands are null
+
+               Example:
+
+               The previous version would return 'true' for expression: (null < new System.TimeSpan(15,0,0))
+               Now it returns false. That is now the exactly result which original c# code would return.
+           */
+
+            if (c1.Value == null || c2.Value == null)
+                return false;
+            else
+            {
+                var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
+                return compareRes < 0;
+            }
+        }
+
+        public static bool operator >=(LambdaParameterWrapper c1, LambdaParameterWrapper c2)
+        {
+            /*
+                Change 20.06.2017
+
+                This operator should return false if one or both operands are null
+
+                Example:
+
+                The previous version would return 'true' for expression: (null >= new System.TimeSpan(15,0,0))
+                Now it returns false. That is now the exactly result which original c# code would return.
+            */
+
+            if (c1.Value == null || c2.Value == null)
+                return false;
+            else
+            {
+                var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
+                return compareRes >= 0;
+            }
+        }
+
+        public static bool operator <=(LambdaParameterWrapper c1, LambdaParameterWrapper c2)
+        {
+            /*
+                 Change 20.06.2017
+
+                 This operator should return false if one or both operands are null
+
+                 Example:
+
+                 The previous version would return 'true' for expression: (null <= new System.TimeSpan(15,0,0))
+                 Now it returns false. That is now the exactly result which original c# code would return.
+            */
+
+            if (c1.Value == null || c2.Value == null)
+                return false;
+            else
+            {
+                var compareRes = ValueComparer.Instance.Compare(c1.Value, c2.Value);
+                return compareRes <= 0;
+            }
+        }
 
 		public static LambdaParameterWrapper operator !(LambdaParameterWrapper c1) {
 			var c1bool = Convert.ToBoolean(c1.Value, CultureInfo.InvariantCulture);


### PR DESCRIPTION
 This operators should return false if one or both operands are null

Example:

The previous version would return 'true' for expression: (new System.TimeSpan(15,0,0) >  null)
Now it returns false. That is now the exactly result which original c# code would return.