### PR TITLE
Optionally allow real numbers with no leading zeroes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.dll
 *.targets
 project.lock.json
+.idea/

--- a/src/NReco.LambdaParser.Tests/LambdaParserTests.cs
+++ b/src/NReco.LambdaParser.Tests/LambdaParserTests.cs
@@ -216,6 +216,22 @@ namespace NReco.Linq.Tests {
 			Console.WriteLine("10000 iterations: {0}", sw.Elapsed);
 		}
 
+		[Fact]
+		public void AllowNoLeadingZeroesFalse()
+		{
+			var parser = new LambdaParser { AllowNoLeadingZeroes = false };
+			var exception = Assert.Throws<LambdaParserException>(() => parser.Eval(".6", new Dictionary<string, object>()));
+			Assert.Equal(".6", exception.Expression);
+			Assert.Equal(0, exception.Index);
+		}
+		
+		[Fact]
+		public void AllowNoLeadingZeroesTrue()
+		{
+			var parser = new LambdaParser { AllowNoLeadingZeroes = true };
+			var result = parser.Eval(".6", new Dictionary<string, object>());
+			Assert.Equal(0.6m, result);
+		}
 
 		public class TestBaseClass
 		{

--- a/src/NReco.LambdaParser/Linq/LambdaParser.cs
+++ b/src/NReco.LambdaParser/Linq/LambdaParser.cs
@@ -44,6 +44,11 @@ namespace NReco.Linq {
 		/// Gets or sets whether LambdaParser should use the cache for parsed expressions.
 		/// </summary>
 		public bool UseCache { get; set; }
+		
+		/// <summary>
+		/// Gets or sets whether LambdaParser should allow numbers without leading zeroes.
+		/// </summary>
+		public bool AllowNoLeadingZeroes { get; set; }
 
 		/// <summary>
 		/// Allows usage of "=" for equality comparison (in addition to "=="). False by default.
@@ -72,6 +77,7 @@ namespace NReco.Linq {
 
 		public LambdaParser() {
 			UseCache = true;
+			AllowNoLeadingZeroes = false;
 			AllowSingleEqualSign = false;
 			AllowVars = false;
 			Comparer = ValueComparer.Instance;
@@ -191,6 +197,14 @@ namespace NReco.Linq {
 				if (Array.IndexOf(delimiters, s[lexem.End]) >= 0) {
 					if (lexem.Type == LexemType.Unknown) {
 						lexem.End++;
+						if (AllowNoLeadingZeroes 
+								&& lexem.Start == lexem.End - 1 
+								&& s[lexem.Start] == '.' 
+								&& lexem.End < s.Length 
+								&& char.IsDigit(s[lexem.End])) {
+							lexem.Type = LexemType.NumberConstant;
+							continue;
+						}
 						lexem.Type = LexemType.Delimiter;
 						return lexem;
 					}


### PR DESCRIPTION
`LambdaParser` is rather restrictive when parsing real numbers. It will throw an exception if the value is written with no leading zeroes (e.g. `".6"` rather than `"0.6"`).

This pull request adds the capability to parse reals with no leading zeroes.

To avoid changing the behavior of the library the functionality is controlled with a feature flag.

Use
```csharp
var parser = new LambdaParser { AllowNoLeadingZeroes = true };
```
to turn it on.